### PR TITLE
replace viewproptypes rn to deprecated rn prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "logo": "https://opencollective.com/opencollective/logo.txt"
   },
   "dependencies": {
-    "prop-types": "^15.6.2"
+    "prop-types": "^15.6.2",
+    "deprecated-react-native-prop-types": "^5.0.0"
   },
   "devDependencies": {
     "@babel/runtime": "^7.3.1",

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -5,7 +5,6 @@ import {
   findNodeHandle,
   Platform,
   NativeModules,
-  ViewPropTypes,
   requireNativeComponent,
   View,
   ActivityIndicator,
@@ -13,6 +12,7 @@ import {
   StyleSheet,
   PermissionsAndroid,
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 import type { FaceFeature } from './FaceDetector';
 


### PR DESCRIPTION
Replace deprecated ViewPropTypes from RN to ViewPropTypes from Deprecated React Native Prop Types library